### PR TITLE
fix: remove backup watch event in middleware, sysevent

### DIFF
--- a/cmd/middleware/main.go
+++ b/cmd/middleware/main.go
@@ -9,7 +9,6 @@ import (
 	_ "net/http/pprof"
 
 	"bytetrade.io/web3os/tapr/cmd/middleware/app"
-	"bytetrade.io/web3os/tapr/cmd/middleware/operator/backup"
 	kvrocksbakcup "bytetrade.io/web3os/tapr/cmd/middleware/operator/kvrocks-bakcup"
 	kvrocksrestore "bytetrade.io/web3os/tapr/cmd/middleware/operator/kvrocks-restore"
 	middlewarerequest "bytetrade.io/web3os/tapr/cmd/middleware/operator/middleware-request"
@@ -52,7 +51,7 @@ func main() {
 	kvrocksBackupController := kvrocksbakcup.NewController(config, apiCtx)
 	kvrocksRestoreController := kvrocksrestore.NewController(config, apiCtx)
 
-	backupWatcher := backup.NewWatcher(config, apiCtx)
+	// backupWatcher := backup.NewWatcher(config, apiCtx)
 
 	runControllers := func() {
 		go func() { utilruntime.Must(pgclusterController.Run(1)) }()
@@ -63,7 +62,7 @@ func main() {
 		go func() { utilruntime.Must(kvrocksBackupController.Run(1)) }()
 		go func() { utilruntime.Must(kvrocksRestoreController.Run(1)) }()
 		go func() { utilruntime.Must(configMapController.Run(1)) }()
-		go func() { backupWatcher.Start() }()
+		// go func() { backupWatcher.Start() }()
 	}
 
 	cmd := &cobra.Command{

--- a/cmd/sys-event/main.go
+++ b/cmd/sys-event/main.go
@@ -6,11 +6,9 @@ import (
 	"bytetrade.io/web3os/tapr/cmd/sys-event/apiserver"
 	"bytetrade.io/web3os/tapr/cmd/sys-event/watchers"
 	"bytetrade.io/web3os/tapr/cmd/sys-event/watchers/apps"
-	backupWatcher "bytetrade.io/web3os/tapr/cmd/sys-event/watchers/backup"
 	"bytetrade.io/web3os/tapr/cmd/sys-event/watchers/metrics"
 	"bytetrade.io/web3os/tapr/cmd/sys-event/watchers/users"
 	"bytetrade.io/web3os/tapr/cmd/sys-event/watchers/workflows"
-	"bytetrade.io/web3os/tapr/pkg/backup"
 	"bytetrade.io/web3os/tapr/pkg/signals"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
@@ -35,8 +33,8 @@ func main() {
 		(&apps.Subscriber{Subscriber: watchers.NewSubscriber(w).WithNotification(&notification)}).HandleEvent())
 	// watchers.AddToWatchers[login.LoginRecord](w, login.GVR,
 	// 	(&login.Subscriber{Subscriber: watchers.NewSubscriber(w).WithNotification(&notification)}).HandleEvent())
-	watchers.AddToWatchers[backup.Backup](w, backup.BackupGVR,
-		(&backupWatcher.Subscriber{Subscriber: watchers.NewSubscriber(w)}).WithKubeConfig(config).HandleEvent())
+	// watchers.AddToWatchers[backup.Backup](w, backup.BackupGVR,
+	// (&backupWatcher.Subscriber{Subscriber: watchers.NewSubscriber(w)}).WithKubeConfig(config).HandleEvent())
 	watchers.AddToWatchers[corev1.Namespace](w, corev1.SchemeGroupVersion.WithResource("namespaces"),
 		(&workflows.Subscriber{Subscriber: watchers.NewSubscriber(w).WithNotification(&notification)}).WithKubeConfig(config).HandleEvent())
 


### PR DESCRIPTION
Method to remove middleware backup database event and lock the creation of new accounts via sysevent watch event.